### PR TITLE
Fix android build error - Missing Kotlin Maven repo

### DIFF
--- a/src/android/XPush.gradle
+++ b/src/android/XPush.gradle
@@ -4,6 +4,7 @@ buildscript {
         google()
         jcenter()
         mavenCentral()
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
 
     dependencies {

--- a/src/android/XPush.gradle
+++ b/src/android/XPush.gradle
@@ -4,11 +4,10 @@ buildscript {
         google()
         jcenter()
         mavenCentral()
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:+'
+        classpath 'com.android.tools.build:gradle:3.+'
         classpath 'com.google.gms:google-services:4.1.0'
     }
 }


### PR DESCRIPTION
Fix error Could not find org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.360-eap-25 - Missing Kotlin Maven repo

Similar to this: https://github.com/chemerisuk/cordova-support-google-services/pull/26